### PR TITLE
Add ChannelSpecificData

### DIFF
--- a/app/src/main/java/io/github/boogiemonster1o1/eyeyoureadyforit/data/ChannelSpecificData.java
+++ b/app/src/main/java/io/github/boogiemonster1o1/eyeyoureadyforit/data/ChannelSpecificData.java
@@ -1,0 +1,59 @@
+package io.github.boogiemonster1o1.eyeyoureadyforit.data;
+
+import discord4j.common.util.Snowflake;
+
+public class ChannelSpecificData {
+	private Snowflake messageId;
+	private EyeEntry current;
+	private final Snowflake channelId;
+	private final GuildSpecificData gsd;
+	private TourneyData tourneyData = null;
+
+	public ChannelSpecificData(Snowflake channelId, GuildSpecificData gsd) {
+		this.channelId = channelId;
+		this.gsd = gsd;
+	}
+
+	public GuildSpecificData getGuildSpecificData() {
+		return gsd;
+	}
+
+	public Snowflake getChannelId() {
+		return channelId;
+	}
+
+	public Snowflake getMessageId() {
+		return messageId;
+	}
+
+	public void setMessageId(Snowflake messageId) {
+		this.messageId = messageId;
+	}
+
+	public EyeEntry getCurrent() {
+		return current;
+	}
+
+	public boolean isTourney() {
+		return this.tourneyData != null;
+	}
+
+	public void setTourneyData(TourneyData tourneyData) {
+		this.tourneyData = tourneyData;
+	}
+
+	public TourneyData getTourneyData() {
+		return tourneyData;
+	}
+
+	public void setCurrent(EyeEntry current) {
+		this.current = current;
+	}
+
+	public void reset() {
+		synchronized (GuildSpecificData.LOCK) {
+			this.setCurrent(null);
+			this.setMessageId(null);
+		}
+	}
+}

--- a/app/src/main/java/io/github/boogiemonster1o1/eyeyoureadyforit/data/GuildSpecificData.java
+++ b/app/src/main/java/io/github/boogiemonster1o1/eyeyoureadyforit/data/GuildSpecificData.java
@@ -4,15 +4,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 import discord4j.common.util.Snowflake;
-import io.github.boogiemonster1o1.eyeyoureadyforit.App;
 
 public final class GuildSpecificData {
 	public static final Object LOCK = new Object(){};
 	private static final Map<Snowflake, GuildSpecificData> GUILD_SPECIFIC_DATA_MAP = new HashMap<>();
+	private final Map<Snowflake, ChannelSpecificData> channelSpecificData = new HashMap<>();
 	private final Snowflake guildId;
-	private Snowflake messageId;
-	private EyeEntry current;
-	private TourneyData tourneyData = null;
 
 	private GuildSpecificData(Snowflake guildId) {
 		this.guildId = guildId;
@@ -22,42 +19,11 @@ public final class GuildSpecificData {
 		return GUILD_SPECIFIC_DATA_MAP.computeIfAbsent(guildId, GuildSpecificData::new);
 	}
 
+	public ChannelSpecificData getChannel(Snowflake channelId) {
+		return channelSpecificData.computeIfAbsent(channelId, (id) -> new ChannelSpecificData(id, this));
+	}
+
 	public Snowflake getGuildId() {
 		return guildId;
-	}
-
-	public Snowflake getMessageId() {
-		return messageId;
-	}
-
-	public void setMessageId(Snowflake messageId) {
-		this.messageId = messageId;
-	}
-
-	public EyeEntry getCurrent() {
-		return current;
-	}
-
-	public boolean isTourney() {
-		return this.tourneyData != null;
-	}
-
-	public void setTourneyData(TourneyData tourneyData) {
-		this.tourneyData = tourneyData;
-	}
-
-	public TourneyData getTourneyData() {
-		return tourneyData;
-	}
-
-	public void setCurrent(EyeEntry current) {
-		this.current = current;
-	}
-
-	public void reset() {
-		synchronized (GuildSpecificData.LOCK) {
-			this.setCurrent(null);
-			this.setMessageId(null);
-		}
 	}
 }


### PR DESCRIPTION
Allows running multiple contexts per guild through the use of a separate context per channel. 

Closes #12 

Notes:
- `GuildSpecificData` has **not** been removed
- The functionality of `GuildSpecificData` has been transferred to `ChannelSpecificdata`
- `GuildSpecificData` serves as a wrapper for multiple `ChannelSpecificData` objects